### PR TITLE
Adds user login to get to /config pages

### DIFF
--- a/api/controllers/HealthController.js
+++ b/api/controllers/HealthController.js
@@ -6,6 +6,9 @@
 
 module.exports = {
   check: function(req, res) {
-    return res.send({status: 'ok'});
+    return res.status(200).send({
+      status: 'ok',
+      session: req.session
+    });
   }
 };

--- a/api/controllers/LoginController.js
+++ b/api/controllers/LoginController.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+
+  view: function(req, res) {
+    return res.view('login', {showError: req.query.error});
+  },
+
+  login: function(req, res) {
+    let username = req.body.username;
+    let password = req.body.password;
+    PhoenixService.login(username, password, function(err, response, body) {
+      if (err) {
+        return res.status(500).send(err);
+      }
+
+      if (typeof body === 'object'
+        && typeof body.user === 'object'
+        && typeof body.user.roles === 'object'
+        && Object.keys(body.user.roles).indexOf(PhoenixService.ADMIN_ROLE) >= 0) {
+
+        req.session.isAdmin = true;
+        return res.redirect('config');
+
+      }
+      else {
+        return res.redirect('login?error=true');
+      }
+
+    });
+  },
+
+};

--- a/api/policies/isAdmin.js
+++ b/api/policies/isAdmin.js
@@ -1,12 +1,11 @@
 'use strict';
 
 var request = require('request');
-var AUTHENTICATED_ROLE = '2';
 var ADMIN_ROLE = '3';
 
 module.exports = function(req, res, next) {
-  if (typeof req.session.isAuthenticated !== 'undefined'
-      && req.session.isAuthenticated === true) {
+  if (typeof req.session.isAdmin !== 'undefined'
+      && req.session.isAdmin === true) {
     return next();
   }
 
@@ -22,9 +21,8 @@ module.exports = function(req, res, next) {
     if (typeof body === 'object'
         && typeof body.user === 'object'
         && typeof body.user.roles === 'object'
-        && (Object.keys(body.user.roles).indexOf(AUTHENTICATED_ROLE) >= 0
-          || Object.keys(body.user.roles).indexOf(ADMIN_ROLE) >= 0)) {
-      req.session.isAuthenticated = true;
+        && Object.keys(body.user.roles).indexOf(ADMIN_ROLE) >= 0) {
+      req.session.isAdmin = true;
       next();
     }
     else {

--- a/api/policies/isAdmin.js
+++ b/api/policies/isAdmin.js
@@ -1,12 +1,17 @@
 'use strict';
 
 var request = require('request');
-var ADMIN_ROLE = '3';
 
 module.exports = function(req, res, next) {
   if (typeof req.session.isAdmin !== 'undefined'
       && req.session.isAdmin === true) {
     return next();
+  }
+
+  if (typeof req.body === 'undefined'
+      || typeof req.body.username !== 'string'
+      || typeof req.body.password !== 'string') {
+    return res.redirect('/login');
   }
 
   // Log into Phoenix
@@ -21,12 +26,12 @@ module.exports = function(req, res, next) {
     if (typeof body === 'object'
         && typeof body.user === 'object'
         && typeof body.user.roles === 'object'
-        && Object.keys(body.user.roles).indexOf(ADMIN_ROLE) >= 0) {
+        && Object.keys(body.user.roles).indexOf(PhoenixService.ADMIN_ROLE) >= 0) {
       req.session.isAdmin = true;
       next();
     }
     else {
-      return res.forbidden('You are not permitted to perform this action.');
+      return res.redirect('/login');
     }
   });
 };

--- a/api/policies/isAuthenticated.js
+++ b/api/policies/isAuthenticated.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var request = require('request');
+var AUTHENTICATED_ROLE = '2';
+var ADMIN_ROLE = '3';
+
+module.exports = function(req, res, next) {
+  if (typeof req.session.isAuthenticated !== 'undefined'
+      && req.session.isAuthenticated === true) {
+    return next();
+  }
+
+  // Log into Phoenix
+  PhoenixService.login(req.body.username, req.body.password, function(err, response, body) {
+    if (err) {
+      return res.status(500).send({
+        message: 'There was an error authenticating against Phoenix',
+        data: err
+      });
+    }
+
+    if (typeof body === 'object'
+        && typeof body.user === 'object'
+        && typeof body.user.roles === 'object'
+        && (Object.keys(body.user.roles).indexOf(AUTHENTICATED_ROLE) >= 0
+          || Object.keys(body.user.roles).indexOf(ADMIN_ROLE) >= 0)) {
+      req.session.isAuthenticated = true;
+      next();
+    }
+    else {
+      return res.forbidden('You are not permitted to perform this action.');
+    }
+  });
+};

--- a/api/services/PhoenixService.js
+++ b/api/services/PhoenixService.js
@@ -7,6 +7,10 @@
 var request = require('request');
 
 module.exports = {
+  /**
+   * Admin role constant.
+   */
+  ADMIN_ROLE: '3',
 
   /**
    * User login.

--- a/api/services/PhoenixService.js
+++ b/api/services/PhoenixService.js
@@ -1,0 +1,39 @@
+/**
+ * Service for Phoenix API calls.
+ */
+
+'use strict';
+
+var request = require('request');
+
+module.exports = {
+
+  /**
+   * User login.
+   *
+   * @param username {string}
+   * @param password {string}
+   * @param callback {function}
+   */
+  login: function(username, password, callback) {
+    let options = {
+      url: sails.config.phoenix.url + '/auth/login',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      },
+      body: {
+        username: username,
+        password: password
+      },
+      json: true
+    };
+
+    // Log into Phoenix
+    request(options, function(err, response, body) {
+      callback(err, response, body);
+    });
+  },
+
+};

--- a/assets/styles/gambit.css
+++ b/assets/styles/gambit.css
@@ -25,6 +25,10 @@ tr {
   padding: 12px;
 }
 
+#login-form {
+  margin: 48px 0;
+}
+
 .field-label + p {
   font-size: 16px;
 }

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -35,4 +35,9 @@ module.exports = {
   //   level: "silent"
   // }
 
+  // Phoenix API settings
+  phoenix: {
+    url: 'https://www.dosomething.org/api/v1'
+  },
+
 };

--- a/config/policies.js
+++ b/config/policies.js
@@ -48,4 +48,9 @@ module.exports.policies = {
 		// before letting any users feed our rabbits
 		// feed : ['isNiceToAnimals', 'hasRabbitFood']
 	// }
+
+  ConfigController: {
+    '*': 'isAdmin'
+  },
+
 };

--- a/config/routes.js
+++ b/config/routes.js
@@ -47,6 +47,12 @@ module.exports.routes = {
   ***************************************************************************/
 
   /**
+   * Login view
+   */
+  'get  /login': 'LoginController.view',
+  'post /login': 'LoginController.login',
+
+  /**
    * Admin config views.
    */
 

--- a/config/session.js
+++ b/config/session.js
@@ -67,11 +67,12 @@ module.exports.session = {
   *                                                                          *
   ***************************************************************************/
 
-  // adapter: 'mongo',
-  // host: 'localhost',
-  // port: 27017,
-  // db: 'sails',
-  // collection: 'sessions',
+  adapter: 'connect-mongo',
+  url: 'mongodb://localhost:27017/ds-mdata-responder',
+  host: 'localhost',
+  port: 27017,
+  db: 'ds-mdata-responder',
+  collection: 'sessions',
 
   /***************************************************************************
   *                                                                          *

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "a Sails application",
   "keywords": [],
   "dependencies": {
+    "connect-mongo": "^1.1.0",
     "ejs": "2.3.4",
     "grunt": "0.4.5",
     "grunt-contrib-clean": "0.6.0",
@@ -20,6 +21,7 @@
     "grunt-sync": "0.2.4",
     "include-all": "~0.1.6",
     "rc": "1.0.1",
+    "request": "^2.71.0",
     "request-retry": "^0.1.1",
     "sails": "~0.12.1",
     "sails-disk": "~0.10.9",

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,0 +1,20 @@
+<% if (showError) { %>
+<div class="messages -error">
+  Login failed :(
+</div>
+<% } %>
+<form id="login-form" method="post" action="/login">
+    <div class="form-item">
+      <label class="field-label">Username:</label>
+      <input type="text" class="text-field" name="username" placeholder="Username (from Phoenix)" required>
+    </div>
+
+    <div class="form-item">
+      <label class="field-label">Password:</label>
+      <input type="password" class="text-field" name="password" placeholder="Password" required>
+    </div>
+
+    <div class="form-actions">
+      <input type="submit" class="button" value="Login">
+    </div>
+</form>


### PR DESCRIPTION
#### What's this PR do?

Don't be fooled by the `reportback` branch name, that's not what this ended up being about. An intermediary step to get to that point was to allow the app to authenticate against Phoenix. This PR sets up user authentication for editing the configs.

Users who try to go to any `/config` page will first have to login before they're able to continue.
#### What interesting things should I look at?
- **Sessions** are handled by the `connect-mongo` library
- An `isAdmin` **policy** is used by any action against the ConfigController
- Both in `isAdmin` and `LoginController.login` you'll see that `req.session.isAdmin = true` so that we don't require an auth request be sent to Phoenix every time
- **PhoenixService** is where the login call lives and where future Phoenix API implementations will happen
#### Am I gonna merge this in whether someone sees this or not?

Yea, probably.

cc: @aaronschachter @DFurnes @sergii-tkachenko 
